### PR TITLE
Fix: 暗色主题下，歌单详情对比度太低

### DIFF
--- a/packages/web/components/DescriptionViewer.tsx
+++ b/packages/web/components/DescriptionViewer.tsx
@@ -82,7 +82,7 @@ function DescriptionViewer({
               <div className='absolute -bottom-24 flex w-full justify-center'>
                 <div
                   onClick={onClose}
-                  className='flex h-14 w-14 items-center justify-center rounded-full bg-white/10 transition-colors duration-300 hover:bg-white/20 hover:text-white/70'
+                  className='flex h-14 w-14 items-center justify-center rounded-full bg-black/10 transition-colors duration-300 hover:bg-black/20 hover:text-black/70 dark:bg-white/10 dark:text-white/50 dark:hover:bg-white/20 dark:hover:text-white/70'
                 >
                   <Icon name='x' className='h-6 w-6' />
                 </div>

--- a/packages/web/components/DescriptionViewer.tsx
+++ b/packages/web/components/DescriptionViewer.tsx
@@ -27,7 +27,7 @@ function DescriptionViewer({
       <AnimatePresence>
         {isOpen && (
           <motion.div
-            className='fixed inset-0 z-30 bg-black/70 backdrop-blur-3xl dark:bg-white/70 '
+            className='fixed inset-0 z-30 bg-white/70 backdrop-blur-3xl dark:bg-black/70 '
             initial={{ opacity: 0 }}
             animate={{ opacity: 1, transition: { duration: 0.3 } }}
             exit={{ opacity: 0, transition: { duration: 0.3, delay: 0.3 } }}
@@ -48,7 +48,7 @@ function DescriptionViewer({
           >
             <div className='relative'>
               {/* Title */}
-              <div className='line-clamp-1 absolute -top-8 mx-44 max-w-2xl select-none text-32 font-extrabold text-neutral-100 dark:text-neutral-700'>
+              <div className='line-clamp-1 absolute -top-8 mx-44 max-w-2xl select-none text-32 font-extrabold text-neutral-700 dark:text-neutral-100'>
                 {title}
               </div>
 
@@ -73,7 +73,7 @@ function DescriptionViewer({
                 >
                   <p
                     dangerouslySetInnerHTML={{ __html: description }}
-                    className='mt-8 whitespace-pre-wrap pb-8 text-16 font-bold leading-6 text-neutral-200 dark:text-neutral-700'
+                    className='mt-8 whitespace-pre-wrap pb-8 text-16 font-bold leading-6 text-neutral-700 dark:text-neutral-200'
                   ></p>
                 </div>
               </div>

--- a/packages/web/components/DescriptionViewer.tsx
+++ b/packages/web/components/DescriptionViewer.tsx
@@ -27,7 +27,7 @@ function DescriptionViewer({
       <AnimatePresence>
         {isOpen && (
           <motion.div
-            className='fixed inset-0 z-30 bg-black/70 dark:bg-white/70 backdrop-blur-3xl'
+            className='fixed inset-0 z-30 bg-black/70 backdrop-blur-3xl dark:bg-white/70 '
             initial={{ opacity: 0 }}
             animate={{ opacity: 1, transition: { duration: 0.3 } }}
             exit={{ opacity: 0, transition: { duration: 0.3, delay: 0.3 } }}
@@ -48,7 +48,7 @@ function DescriptionViewer({
           >
             <div className='relative'>
               {/* Title */}
-              <div className='line-clamp-1 absolute -top-8 mx-44 max-w-2xl select-none text-32 font-extrabold text-neutral-100'>
+              <div className='line-clamp-1 absolute -top-8 mx-44 max-w-2xl select-none text-32 font-extrabold text-neutral-100 dark:text-neutral-700'>
                 {title}
               </div>
 
@@ -73,7 +73,7 @@ function DescriptionViewer({
                 >
                   <p
                     dangerouslySetInnerHTML={{ __html: description }}
-                    className='mt-8 whitespace-pre-wrap pb-8 text-16 font-bold leading-6 text-neutral-200'
+                    className='mt-8 whitespace-pre-wrap pb-8 text-16 font-bold leading-6 text-neutral-200 dark:text-neutral-700'
                   ></p>
                 </div>
               </div>


### PR DESCRIPTION
之前：

![iShot_2023-10-19_23 41 44](https://github.com/Sherlockouo/music/assets/30215105/f0475e8a-04a5-4666-a340-3e7d378593da)


之后：

![iShot_2023-10-19_23 49 18](https://github.com/Sherlockouo/music/assets/30215105/bd8c600a-c23b-4f89-a83e-19a9f697cdf2)


另外，明、暗主题对应的详情视图的配色，是不是反了？至少我感觉是反了……老哥们看看，如果反了 at 我，我调换下。