### PR TITLE
Add installation support for Debian based distributions and NixOS

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -129,11 +129,18 @@ jobs:
           path: ./packages/desktop/release/latest.yml
           if-no-files-found: ignore
 
-      - name: Upload Artifact (Linux)
+      - name: Upload Artifact (Linux Appimage)
         uses: actions/upload-artifact@v3
         with:
           name: R3PLAYX-linux
           path: ./packages/desktop/release/*.AppImage
+          if-no-files-found: ignore
+
+      - name: Upload Artifact (Linux deb)
+        uses: actions/upload-artifact@v3
+        with:
+          name: R3PLAYX-linux-deb
+          path: ./packages/desktop/release/*.deb
           if-no-files-found: ignore
 
       - name: Upload linux latest yml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -129,11 +129,18 @@ jobs:
           path: ./packages/desktop/release/latest.yml
           if-no-files-found: ignore
 
-      - name: Upload Artifact (Linux)
+      - name: Upload Artifact (Linux Appimage)
         uses: actions/upload-artifact@v3
         with:
           name: R3PLAYX-linux
           path: ./packages/desktop/release/*.AppImage
+          if-no-files-found: ignore
+
+      - name: Upload Artifact (Linux deb)
+        uses: actions/upload-artifact@v3
+        with:
+          name: R3PLAYX-linux-deb
+          path: ./packages/desktop/release/*.deb
           if-no-files-found: ignore
 
       - name: Upload linux latest yml

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
 访问本项目的 [Releases](https://github.com/qier222/YesPlayMusic/releases)
 页面下载安装包。
 
+对于 NixOS 上的安装，请参考 [EndCredits/R3PLAYX-nix](https://github.com/EndCredits/R3PLAYX-nix)
+
 ## 📜 开源许可
 
 API 源代码来自 [Binaryify/NeteaseCloudMusicApi](https://github.com/Binaryify/NeteaseCloudMusicApi)

--- a/packages/desktop/.electron-builder.config.js
+++ b/packages/desktop/.electron-builder.config.js
@@ -75,14 +75,13 @@ module.exports = {
   },
   linux: {
     target: [
-      // {
-      //   target: 'deb',
-      //   arch: [
-      //     'x64',
-      //     'arm64',
-      //     // 'armv7l'
-      //   ],
-      // },
+      {
+        target: 'deb',
+        arch: [
+          'x64',
+          'arm64',
+        ],
+      },
       {
         target: 'AppImage',
         arch: ['x64'],
@@ -104,7 +103,7 @@ module.exports = {
       //   arch: ['x64'],
       // },
     ],
-    artifactName: '${productName}-${version}-${os}.${ext}',
+    artifactName: '${productName}-${version}-${os}-${arch}.${ext}',
     category: 'Music',
     icon: './build/icon.png',
   },


### PR DESCRIPTION
Greetings.

This pull request included these content
- Enabling support to deb packaing
- Update README to show NixOS installation reference

After the next release containing the deb package is released. The url for the repo to get the deb packages ( [here for x86_64](https://github.com/EndCredits/R3PLAYX-nix/blob/fe770584b44a44d29cf89c4ca08a2ae8362bb39c/pkgs/r3playx/default.nix#L38) and [here for arm64](https://github.com/EndCredits/R3PLAYX-nix/blob/fe770584b44a44d29cf89c4ca08a2ae8362bb39c/pkgs/r3playx/default.nix#L42) ) will change from my test build to your production build.

As for why the deb package is used to build the corresponding nix derivation, it is because it saves trouble and saves the user's building time. The separate packaging repository is mainly because the code repository needs frequent changes. Flakes dependencies should be stable until the next release.

Test: build passed and all works fine on NixOS x86_64-linux ( Hyprland with wayland and Gnome with X11

![R3PLAYX Running on the NixOS with Hyprland HIDPI enabled](https://github.com/Sherlockouo/music/assets/64133324/33a6642a-2977-48a1-b426-f4abf9e335e6)

Thank you for your great effort.