### PR TITLE
Add support for deleting music from play queue

### DIFF
--- a/packages/web/components/ContextMenus/TrackContextMenu.tsx
+++ b/packages/web/components/ContextMenus/TrackContextMenu.tsx
@@ -92,6 +92,13 @@ const TrackContextMenu = () => {
               },
             },
             {
+              type: 'item',
+              label: t`context-menu.delete-from-queue`,
+              onClick: () => {
+                player.deleteFromPlaylist(Number(dataSourceID))
+              }
+            },
+            {
               type: 'divider',
             },
             {

--- a/packages/web/i18n/locales/en-us.json
+++ b/packages/web/i18n/locales/en-us.json
@@ -137,6 +137,7 @@
     "go-to-album": "Go to album",
     "go-to-artist": "Go to artist",
     "add-to-queue": "Add to Queue",
+    "delete-from-queue": "Delete from Queue",
     "follow": "Follow",
     "unfollow": "Unfollow",
     "followed": "Followed",

--- a/packages/web/i18n/locales/zh-cn.json
+++ b/packages/web/i18n/locales/zh-cn.json
@@ -137,6 +137,7 @@
     "go-to-album": "查看专辑",
     "go-to-artist": "查看艺人",
     "add-to-queue": "添加到播放队列",
+    "delete-from-queue": "从播放队列中删除",
     "unfollow": "取消关注",
     "follow": "关注",
     "followed": "已关注",

--- a/packages/web/utils/player.ts
+++ b/packages/web/utils/player.ts
@@ -570,6 +570,12 @@ export class Player {
     if (!this.trackList.includes(trackID)) {
       return
     }
+    // Check whether we are deleting the content that we are playing
+    if (this.track?.id != undefined && this.track?.id != trackID){
+      this.trackList = this.trackList.filter(item => item != trackID)
+      return
+    }
+    this.nextTrack() // If we are deleting current playing. Switch to the next first
     this.trackList = this.trackList.filter(item => item != trackID)
   }
 

--- a/packages/web/utils/player.ts
+++ b/packages/web/utils/player.ts
@@ -575,8 +575,10 @@ export class Player {
       this.trackList = this.trackList.filter(item => item != trackID)
       return
     }
-    this.nextTrack() // If we are deleting current playing. Switch to the next first
+    // If we are deleting current playing. Switch to the next first
+    this.prevTrack()
     this.trackList = this.trackList.filter(item => item != trackID)
+    this.nextTrack()
   }
 
   /**

--- a/packages/web/utils/player.ts
+++ b/packages/web/utils/player.ts
@@ -560,6 +560,20 @@ export class Player {
   }
 
   /**
+   * deleteFromPlaylist() - function to remove a track from current play queue
+   * 
+   * @param trackID
+   */
+
+  deleteFromPlaylist(trackID: number) {
+    // Check if the song existed in the tracklist
+    if (!this.trackList.includes(trackID)) {
+      return
+    }
+    this.trackList = this.trackList.filter(item => item != trackID)
+  }
+
+  /**
    *
    * @param trackID
    */


### PR DESCRIPTION
Greetings, devs.

This pull request attempting to implement a feature requested by #111

When it comes to why we need commit ee753082ab. I think It's an inelegant approach directly hacking trackList to modify trackID. So I choose to check whether we are attempting to delete the song we are currently playing. If so we switch to previous song first then delete the song that user wants to delete. After that switch to the next song and continue our play.

Test: Build and basic function check, try to delete song from the playing queue and it works

CI build can be found here: [22](https://github.com/EndCredits/music/actions/runs/7724145968)