### PR TITLE
fix: Construct recent queue track id list as well

### DIFF
--- a/packages/web/pages/My/Recent.tsx
+++ b/packages/web/pages/My/Recent.tsx
@@ -46,6 +46,10 @@ const Recent = () => {
 
     setHasMore(dataSource.length < resp.data.total)
 
+    const songIDList = resp.data ? resp.data.list.map((song: RecentSongs) => song.data.id) : []
+    let arr = [...songIDs, ...songIDList]
+    setSongIDs([...new Set(arr)])
+
     const recentSongs = resp.data ? resp.data.list.map((song: RecentSongs) => song.data) : []
     
     setDatasource(recentSongs)


### PR DESCRIPTION
This commit attempts to fix https://github.com/Sherlockouo/music/issues/117

This issue may be caused by the "Recent Songs" component not updating the song id at the same time when it is initialized. So add a simple implementation to update the recent play queue statefully so that the recent queue can be played correctly.

Test: Build and boot, tap recent song tab and try to play music, works fine on both NixOS and Windows
CI Build Artifacts: https://github.com/EndCredits/music/actions/runs/7872780723