### PR TITLE
fix(web): correct shortcut display on Windows by detecting platform client-side

### DIFF
--- a/packages/web/hooks/useOSPlatform.ts
+++ b/packages/web/hooks/useOSPlatform.ts
@@ -4,18 +4,31 @@ import { useAsync } from 'react-use'
 export const supportedOSPlatform = ['darwin', 'win32', 'linux'] as const
 export type SupportedOSPlatform = typeof supportedOSPlatform[number]
 
+const detectPlatform = (): SupportedOSPlatform => {
+  const userAgent = navigator.userAgent.toLowerCase()
+  const platform = navigator.platform?.toLowerCase() || ''
+
+  if (platform.includes('win32') || platform.includes('win64') || userAgent.includes('windows')) {
+    return 'win32'
+  }
+  if (platform.includes('mac') || userAgent.includes('macintosh')) {
+    return 'darwin'
+  }
+  return 'linux'
+}
+
 const getPlatform = async () => {
   return await window.ipcRenderer?.invoke(IpcChannels.GetPlatform)
 }
 
 const useOSPlatform = (): SupportedOSPlatform => {
   if (!window.ipcRenderer) {
-    return supportedOSPlatform[0]
+    return detectPlatform()
   }
 
   const { value: platform } = useAsync(getPlatform, [])
 
-  return platform ?? supportedOSPlatform[0]
+  return platform ?? detectPlatform()
 }
 
 export default useOSPlatform


### PR DESCRIPTION
Fixes #142

Windows users were seeing macOS shortcut symbols (⌘, ⌥, ⌃) in Settings because `useOSPlatform` defaulted to `'darwin'` before the IPC platform call resolved.

Now it detects the platform from `navigator.userAgent` / `navigator.platform` as a fallback, so Windows and Linux users see the correct shortcuts immediately.
