### PR TITLE
fix(desktop): resolve window maximize, titlebar interactions, and keyboard shortcut leaks

### DIFF
--- a/packages/desktop/main/ipcMain.ts
+++ b/packages/desktop/main/ipcMain.ts
@@ -63,15 +63,14 @@ function initWindowIpcMain(win: BrowserWindow | null) {
     win?.minimize()
   })
 
-  let isMaximized = false
   let unMaximizeSize: { width: number; height: number } | null = null
   let windowPosition: { x: number; y: number } | null = null
   on(IpcChannels.MaximizeOrUnmaximize, () => {
     if (!win) return false
 
-    if (isMaximized) {
+    if (win.isMaximized()) {
       if (unMaximizeSize) {
-        win.setSize(unMaximizeSize.width, unMaximizeSize.width, true)
+        win.setSize(unMaximizeSize.width, unMaximizeSize.height, true)
       }
       if (windowPosition) {
         win.setPosition(windowPosition.x, windowPosition.y, true)
@@ -79,14 +78,13 @@ function initWindowIpcMain(win: BrowserWindow | null) {
       win.unmaximize()
     } else {
       const size = win.getSize()
-      unMaximizeSize = { width: size[1], height: size[0] }
+      unMaximizeSize = { width: size[0], height: size[1] }
       const position = win.getPosition()
       windowPosition = { x: position[0], y: position[1] }
       win.maximize()
     }
 
-    isMaximized = !isMaximized
-    win.webContents.send(IpcChannels.IsMaximized, isMaximized)
+    win.webContents.send(IpcChannels.IsMaximized, win.isMaximized())
   })
 
   on(IpcChannels.MinimizeOrUnminimize, () => {
@@ -94,12 +92,10 @@ function initWindowIpcMain(win: BrowserWindow | null) {
 
     if (win.isMinimized() || !win.isFocused()) {
       win.show()
+      win.focus()
     } else {
       win.minimize()
     }
-
-    isMaximized = !isMaximized
-    win.webContents.send(IpcChannels.IsMaximized, isMaximized)
   })
 
   on(IpcChannels.Close, () => {
@@ -116,8 +112,8 @@ function initWindowIpcMain(win: BrowserWindow | null) {
   })
 
   handle(IpcChannels.IsMaximized, () => {
-    if (!win) return
-    return isMaximized
+    if (!win) return false
+    return win.isMaximized()
   })
 }
 

--- a/packages/desktop/main/keyboardShortcuts.ts
+++ b/packages/desktop/main/keyboardShortcuts.ts
@@ -51,8 +51,8 @@ export const bindingKeyboardShortcuts = (
       win.addListener('blur', handleBlur)
 
       win.once('close', () => {
-        webContexts.removeListener('focus', handleFocus)
-        webContexts.removeListener('blur', handleBlur)
+        win.removeListener('focus', handleFocus)
+        win.removeListener('blur', handleBlur)
         mainWindowFocused = false
         createMenu(webContexts, !mainWindowFocused)
       })
@@ -81,47 +81,43 @@ const bindingGlobalKeyboardShortcuts = (
   const platform = getPlatform()
   const platformShortcuts = shortcuts[platform] as KeyboardShortcuts
 
-  if (platformShortcuts.playPause[1]) {
-    globalShortcut.register(formatForAccelerator(platformShortcuts.playPause[1])!, () => {
-      webContexts.send(IpcChannels.PlayOrPause)
-    })
+  const safeRegister = (shortcut: string[] | null, callback: () => void) => {
+    const accelerator = formatForAccelerator(shortcut)
+    if (!accelerator) return
+    try {
+      globalShortcut.register(accelerator, callback)
+    } catch (err) {
+      console.error('Failed to register global shortcut:', accelerator, err)
+    }
   }
 
-  if (platformShortcuts.next[1]) {
-    globalShortcut.register(formatForAccelerator(platformShortcuts.next[1])!, () => {
-      webContexts.send(IpcChannels.Next)
-    })
-  }
+  safeRegister(platformShortcuts.playPause[1], () => {
+    webContexts.send(IpcChannels.PlayOrPause)
+  })
 
-  if (platformShortcuts.previous[1]) {
-    globalShortcut.register(formatForAccelerator(platformShortcuts.previous[1])!, () => {
-      webContexts.send(IpcChannels.Previous)
-    })
-  }
+  safeRegister(platformShortcuts.next[1], () => {
+    webContexts.send(IpcChannels.Next)
+  })
 
-  if (platformShortcuts.favorite[1]) {
-    globalShortcut.register(formatForAccelerator(platformShortcuts.favorite[1])!, () => {
-      webContexts.send(IpcChannels.Like)
-    })
-  }
+  safeRegister(platformShortcuts.previous[1], () => {
+    webContexts.send(IpcChannels.Previous)
+  })
 
-  if (platformShortcuts.volumeUp[1]) {
-    globalShortcut.register(formatForAccelerator(platformShortcuts.volumeUp[1])!, () => {
-      webContexts.send(IpcChannels.VolumeUp)
-    })
-  }
+  safeRegister(platformShortcuts.favorite[1], () => {
+    webContexts.send(IpcChannels.Like)
+  })
 
-  if (platformShortcuts.volumeDown[1]) {
-    globalShortcut.register(formatForAccelerator(platformShortcuts.volumeDown[1])!, () => {
-      webContexts.send(IpcChannels.VolumeDown)
-    })
-  }
+  safeRegister(platformShortcuts.volumeUp[1], () => {
+    webContexts.send(IpcChannels.VolumeUp)
+  })
 
-  if (platformShortcuts.switchVisibility[1]) {
-    globalShortcut.register(formatForAccelerator(platformShortcuts.switchVisibility[1])!, () => {
-      ipcMain.emit(IpcChannels.MinimizeOrUnminimize)
-    })
-  }
+  safeRegister(platformShortcuts.volumeDown[1], () => {
+    webContexts.send(IpcChannels.VolumeDown)
+  })
+
+  safeRegister(platformShortcuts.switchVisibility[1], () => {
+    ipcMain.emit(IpcChannels.MinimizeOrUnminimize)
+  })
 }
 
 export const formatForAccelerator = (storeText: string[] | null) => {

--- a/packages/web/components/Topbar/TopbarDesktop.tsx
+++ b/packages/web/components/Topbar/TopbarDesktop.tsx
@@ -122,7 +122,7 @@ const TopbarDesktop = () => {
       {/* Background */}
       <Background />
       {/* Left Part */}
-      <div className='z-10 flex items-center'>
+      <div className='z-10 flex items-center' onDoubleClick={(e) => e.stopPropagation()}>
         <NavigationButtons />
         {/* Dividing line */}
         <div className='mx-6 h-4 w-px'></div>
@@ -131,7 +131,7 @@ const TopbarDesktop = () => {
       </div>
 
       {/* Right Part */}
-      <div className='z-10 flex gap-2'>
+      <div className='z-10 flex gap-2' onDoubleClick={(e) => e.stopPropagation()}>
         <Theme />
         <SettingsButton />
         <Avatar className='ml-3 h-12 w-12' />


### PR DESCRIPTION
This PR bundles three closely related fixes in the Electron main process and window interactions.

## Fixes #99: Titlebar double-click maximize behavior

**Problem:**
- Double-clicking interactive buttons (navigation, search, settings, avatar) in the topbar accidentally toggles window maximize because the event bubbles up to `TopbarDesktop`'s `onDoubleClick` handler.
- Conversely, double-clicking the empty titlebar area was often unresponsive because `app-region-drag` swallows events on Windows frameless windows, while the fallback `onDoubleClick` only fires on `app-region-no-drag` children.
- Under the hood, the restore logic in `ipcMain.ts` had the width/height swapped and passed `width` twice to `setSize()`.

**Changes:**
- `TopbarDesktop.tsx`: Added `e.stopPropagation()` on the left and right interactive containers so button double-clicks no longer maximize the window.
- `ipcMain.ts`: Fixed `unMaximizeSize = { width: size[0], height: size[1] }` (was `size[1], size[0]`) and corrected `win.setSize(width, height)`.

## Fixes implicit bug: Broken maximize state synchronization

**Problem:**
`ipcMain.ts` manually tracked `isMaximized` with a local boolean. This easily desynchronizes when the user maximizes the window via OS shortcuts (e.g. Win+↑) or edge snapping. The stale state then caused wrong restore behavior and confusing IPC replies.

**Changes:**
- Replaced the manual `isMaximized` variable with `win.isMaximized()` everywhere.
- Removed the erroneous `isMaximized = !isMaximized` inside `MinimizeOrUnminimize`; minimizing a window has nothing to do with its maximized state and was corrupting the UI.

## Fixes #74: Global keyboard shortcuts failing and leaking memory

**Problem:**
- `keyboardShortcuts.ts` added `focus`/`blur` listeners on `win` but attempted to remove them from `webContexts`, so they were **never unregistered**. Every window recreate leaks two listeners on the main process, eventually making shortcuts sluggish or dead.
- `formatForAccelerator()` can return `null`, but the code used a non-null assertion (`!`) and fed it straight into `globalShortcut.register(null)`, which throws an uncaught exception and can kill the shortcut subsystem.

**Changes:**
- Corrected `removeListener` target from `webContexts` to `win`.
- Introduced `safeRegister()` with explicit `null` checks and `try/catch` around every `globalShortcut.register` call.

---

**Testing notes:**
- Window maximize/restore via titlebar double-click and window controls works correctly on Windows.
- Restored window dimensions match the pre-maximize size.
- Global shortcuts can be toggled and rebound without leaking listeners or crashing the main process.
