### PR TITLE
fix(web): resolve critical performance leaks in audio visualization and intervals

### DIFF
--- a/packages/web/components/Animation/AudioVisualization.tsx
+++ b/packages/web/components/Animation/AudioVisualization.tsx
@@ -1,48 +1,65 @@
 import React, { useEffect, useRef } from 'react'
 import player from '@/web/states/player'
-import { useSnapshot } from 'valtio'
 import { State } from '@/web/utils/player'
 
 interface AudioVisualizationProps {}
 
 const AudioVisualization: React.FC<AudioVisualizationProps> = () => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
-  const { state, dataArray } = useSnapshot(player)
-  const devicePixelRatio = window.devicePixelRatio || 1
+  const rafIdRef = useRef<number | null>(null)
 
   useEffect(() => {
     const canvas = canvasRef.current
-    const ctx = canvas!.getContext('2d')
     if (!canvas) return
-    canvas.width = canvas.width * devicePixelRatio
-    canvas.height = canvas?.height * devicePixelRatio
-    var bufferLength = 1024
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const dpr = window.devicePixelRatio || 1
+    const rect = canvas.getBoundingClientRect()
+    const targetWidth = Math.max(1, Math.floor(rect.width * dpr))
+    const targetHeight = Math.max(1, Math.floor(rect.height * dpr))
+    if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
+      canvas.width = targetWidth
+      canvas.height = targetHeight
+    }
+
+    const bufferLength = 1024
 
     const draw = () => {
-      requestAnimationFrame(draw)
+      rafIdRef.current = requestAnimationFrame(draw)
 
-      ctx!.clearRect(0, 0, canvas.width, canvas.height)
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+      if (player.state !== State.Playing) {
+        return
+      }
 
       const barWidth = (canvas.width * 3) / bufferLength
       const maxHeight = canvas.height * 0.8
       let x = 0
 
       for (let i = 0; i < bufferLength; i += 2) {
-        const barHeight = dataArray[i]
+        const barHeight = player.dataArray[i]
         const height = (barHeight / 255) * maxHeight
         const y = canvas.height - height
 
         const hue = (i / bufferLength) * 1500
 
-        ctx!.fillStyle = `hsl(${hue}, 120%, 50%)` // 使用固定颜色，避免模糊
-
-        ctx!.fillRect(x, y, barWidth, height)
+        ctx.fillStyle = `hsl(${hue}, 120%, 50%)`
+        ctx.fillRect(x, y, barWidth, height)
 
         x += barWidth + 1
       }
     }
     draw()
-  }, [state])
+
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current)
+        rafIdRef.current = null
+      }
+    }
+  }, [])
 
   return (
     <>

--- a/packages/web/components/Tools/Devices.tsx
+++ b/packages/web/components/Tools/Devices.tsx
@@ -34,9 +34,10 @@ const AudioOutputDevices = () => {
     }
     getAudioOutputDevices()
     // update devices every 5s
-    setInterval(() => {
+    const intervalId = setInterval(() => {
       getAudioOutputDevices()
     }, 1000 * 5)
+    return () => clearInterval(intervalId)
   }, [])
 
   const handleDeviceChange = (deviceId: MediaDeviceInfo['deviceId']) => {

--- a/packages/web/utils/player.ts
+++ b/packages/web/utils/player.ts
@@ -252,6 +252,9 @@ export class Player {
   }
 
   private async _setupProgressInterval() {
+    if (this._progressInterval) {
+      clearInterval(this._progressInterval)
+    }
     this._progressInterval = setInterval(() => {
       if (this.state === State.Playing) this._progress = _howler.seek()
     }, 1000)


### PR DESCRIPTION
This PR fixes three critical resource leaks that cause steadily increasing CPU/GPU usage and are a contributing factor to animation performance issues on Linux/Wayland (#101).

## 1. AudioVisualization: leaked `requestAnimationFrame` + exponential canvas growth

**File:** `packages/web/components/Animation/AudioVisualization.tsx`

### Problem
- The `requestAnimationFrame` loop was started in `useEffect` but **never cancelled**. Because the effect depended on `[state]`, every play/pause transition started an **additional** animation loop, causing GPU usage to climb indefinitely.
- On every effect rerun, the canvas dimensions were multiplied by `devicePixelRatio`:
  ```ts
  canvas.width = canvas.width * devicePixelRatio
  ```
  This caused the backing store to grow **exponentially** (e.g. 300 → 450 → 675 → …) until it consumed massive GPU memory.
- `ctx` was accessed with a non-null assertion **before** the null-check on `canvas`, which could throw if the ref was empty.

### Fix
- Introduced `rafIdRef` and a proper cleanup function that calls `cancelAnimationFrame` on unmount.
- Replaced the exponential resize with a one-time size calculation based on `getBoundingClientRect()` and `devicePixelRatio`.
- Removed the `[state]` dependency. A single RAF loop is now created on mount; it reads `player.state` and `player.dataArray` directly, so it no longer needs to be torn down and rebuilt on every playback state change.

## 2. Player: leaked progress interval

**File:** `packages/web/utils/player.ts`

### Problem
`_setupProgressInterval()` created a `setInterval` but never cleared the previous one. Although the code checked `if (!this._progressInterval)` before creation, rapid track switching or future refactors could leave stale timers running.

### Fix
Added `clearInterval(this._progressInterval)` before assigning the new interval.

## 3. Devices: leaked enumeration polling

**File:** `packages/web/components/Tools/Devices.tsx`

### Problem
A 5-second `setInterval` polled `navigator.mediaDevices.enumerateDevices()` but was never cleared, so the polling continued even after the component unmounted.

### Fix
Stored the interval ID and returned a cleanup function that calls `clearInterval`.

---

**Impact:**
- Eliminates GPU memory growth from the visualizer.
- Prevents accumulating animation loops and background timers.
- Reduces baseline CPU/battery usage, which is especially noticeable on Wayland and lower-end hardware.
